### PR TITLE
Add latest OpenAi models to ChatBot

### DIFF
--- a/app.json
+++ b/app.json
@@ -484,9 +484,21 @@
               "value": "gpt-3.5-turbo",
               "values": [
                 {
+                  "id": "gpt-4o",
+                  "label": {
+                    "en": "gpt-4o"
+                  }
+                },
+                {
                   "id": "gpt-4",
                   "label": {
                     "en": "gpt-4"
+                  }
+                },
+                {
+                  "id": "gpt-4-turbo",
+                  "label": {
+                    "en": "gpt-4-turbo"
                   }
                 },
                 {

--- a/drivers/chatbot/driver.settings.compose.json
+++ b/drivers/chatbot/driver.settings.compose.json
@@ -14,9 +14,21 @@
         "value": "gpt-3.5-turbo",
         "values": [
           {
+            "id": "gpt-4o",
+            "label": {
+              "en": "gpt-4o"
+            }
+          },
+          {
             "id": "gpt-4",
             "label": {
               "en": "gpt-4"
+            }
+          },
+          {
+            "id": "gpt-4-turbo",
+            "label": {
+              "en": "gpt-4-turbo"
             }
           },
           {


### PR DESCRIPTION
Add latest models to ChatBot device. Specifically
- Add the gpt-4-turbo moniker for stable (non-preview) gpt 4-turbo model selection
- Add the latest gpt-4o model